### PR TITLE
Added timeout to WPS mode

### DIFF
--- a/src/JustWifi.cpp
+++ b/src/JustWifi.cpp
@@ -488,6 +488,8 @@ void JustWifi::_machine() {
 
         case STATE_WPS_START:
 
+            _timeout = millis();
+
             _doCallback(MESSAGE_WPS_START);
 
             _disable();
@@ -527,6 +529,10 @@ void JustWifi::_machine() {
         case STATE_WPS_ONGOING:
             if (5 == _jw_wps_status) {
                 // Still ongoing
+                // Check timeout
+                if (millis() - _timeout > _connect_timeout) {
+                    _state = STATE_WPS_FAILED;
+                }
             } else if (WPS_CB_ST_SUCCESS == _jw_wps_status) {
                 _state = STATE_WPS_SUCCESS;
             } else {


### PR DESCRIPTION
Uses WIFI_CONNECT_TIMEOUT variable in general.h from the espurna source code. (which is set to 60 seconds)

Not sure if this is a default behavior that got overlooked or is undesired, but I know I certainly prefer it as I have been deploying these smartplugs for family and friends that may accidentally knock these devices into WPS or AP mode when manually rebooting (this pull request only times out WPS mode).