### PR TITLE
Add support for WPA Enterprise (PEAP/TTLS only)

### DIFF
--- a/src/JustWifi.cpp
+++ b/src/JustWifi.cpp
@@ -251,6 +251,21 @@ uint8_t JustWifi::_doSTA(uint8_t id) {
 		    _doCallback(MESSAGE_CONNECTING, buffer);
         }
 
+        #ifdef JUSTWIFI_ENABLE_ENTERPRISE
+        if (entry.enterprise_username && entry.enterprise_password) {
+            struct station_config wifi_config;
+            memset(&wifi_config, 0, sizeof(wifi_config));
+            strcpy((char*)wifi_config.ssid, entry.ssid);
+            wifi_station_set_config(&wifi_config);
+            wifi_station_clear_cert_key();
+            wifi_station_clear_enterprise_ca_cert();
+            wifi_station_set_wpa2_enterprise_auth(1);
+            wifi_station_set_enterprise_identity((uint8*)entry.enterprise_username, strlen(entry.enterprise_username));
+            wifi_station_set_enterprise_username((uint8*)entry.enterprise_username, strlen(entry.enterprise_username));
+            wifi_station_set_enterprise_password((uint8*)entry.enterprise_password, strlen(entry.enterprise_password));
+            wifi_station_connect();
+        } else
+        #endif
         if (entry.channel == 0) {
             WiFi.begin(entry.ssid, entry.pass);
         } else {
@@ -628,7 +643,9 @@ bool JustWifi::addNetwork(
     const char * gw,
     const char * netmask,
     const char * dns,
-    bool front
+    bool front,
+    const char * enterprise_username,
+    const char * enterprise_password
 ) {
 
     network_t new_network;
@@ -671,6 +688,10 @@ bool JustWifi::addNetwork(
     }
     if (dns && *dns != 0x00) {
         new_network.dns.fromString(dns);
+    }
+    if (enterprise_username && enterprise_password && *enterprise_username != 0x00 && *enterprise_password != 0x00) {
+        new_network.enterprise_username = strdup(enterprise_username);
+        new_network.enterprise_password = strdup(enterprise_password);
     }
 
     // Defaults

--- a/src/JustWifi.cpp
+++ b/src/JustWifi.cpp
@@ -253,17 +253,33 @@ uint8_t JustWifi::_doSTA(uint8_t id) {
 
         #ifdef JUSTWIFI_ENABLE_ENTERPRISE
         if (entry.enterprise_username && entry.enterprise_password) {
+            // Create config
             struct station_config wifi_config;
             memset(&wifi_config, 0, sizeof(wifi_config));
             strcpy((char*)wifi_config.ssid, entry.ssid);
-            wifi_station_set_config(&wifi_config);
+            wifi_config.bssid_set = 0;
+            *wifi_config.password = 0;
+
+            // Set some defaults
+            wifi_set_opmode(STATION_MODE);
+            wifi_station_set_config_current(&wifi_config);
+            wifi_station_set_enterprise_disable_time_check(1);
             wifi_station_clear_cert_key();
             wifi_station_clear_enterprise_ca_cert();
             wifi_station_set_wpa2_enterprise_auth(1);
+
+            // Set user/pass
             wifi_station_set_enterprise_identity((uint8*)entry.enterprise_username, strlen(entry.enterprise_username));
             wifi_station_set_enterprise_username((uint8*)entry.enterprise_username, strlen(entry.enterprise_username));
             wifi_station_set_enterprise_password((uint8*)entry.enterprise_password, strlen(entry.enterprise_password));
+
+            // Connect, free resources after
             wifi_station_connect();
+            wifi_station_clear_enterprise_identity();
+            wifi_station_clear_enterprise_username();
+            wifi_station_clear_enterprise_password();
+            wifi_station_clear_cert_key();
+            wifi_station_clear_enterprise_ca_cert();
         } else
         #endif
         if (entry.channel == 0) {

--- a/src/JustWifi.h
+++ b/src/JustWifi.h
@@ -28,6 +28,10 @@ along with the JustWifi library.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <ESP8266WiFi.h>
 
+#ifdef JUSTWIFI_ENABLE_ENTERPRISE
+#include "wpa2_enterprise.h"
+#endif
+
 extern "C" {
   #include "user_interface.h"
 }
@@ -66,6 +70,8 @@ typedef struct {
     uint8_t channel;
     uint8_t bssid[6];
     uint8_t next;
+    char * enterprise_username;
+    char * enterprise_password;
 } network_t;
 
 typedef enum {
@@ -138,7 +144,9 @@ class JustWifi {
             const char * gw = NULL,
             const char * netmask = NULL,
             const char * dns = NULL,
-            bool front = false
+            bool front = false,
+            const char * enterprise_username = NULL,
+            const char * enterprise_password = NULL
         );
         bool setSoftAP(
             const char * ssid,


### PR DESCRIPTION
This requires the ``JUSTWIFI_ENABLE_ENTERPRISE`` build flag to be set - in my tests, it adds a whopping 68KB to the OTA size, so should definitely be off by default.
This should work since core 2.0.0, but looking at [the issues](https://github.com/esp8266/Arduino/issues/3442) it only works correctly since core 2.5+ which I've tested.