### PR TITLE
ESP32 compatibility and some fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.3] 2020-03-26
+### Added
+- ESP32 compatibility
+### Fixed
+- STA+AP mode simultanously
+
 ## [2.0.2] 2018-09-13
 ### Fixed
 - Check NO_EXTRA_4K_HEAP flag for WPS support on SDK 2.4.2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JustWifi
 
-JustWifi is a WIFI Manager library for the [Arduino Core for ESP8266][2]. The goal of the library is to manage ONLY the WIFI connection (no webserver, no mDNS,...) from code and in a reliable and flexible way.
+JustWifi is a WIFI Manager library for the [Arduino Core for ESP8266 and ESP32][2]. The goal of the library is to manage ONLY the WIFI connection (no webserver, no mDNS,...) from code and in a reliable and flexible way.
 
-[![version](https://img.shields.io/badge/version-2.0.2-brightgreen.svg)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.3-brightgreen.svg)](CHANGELOG.md)
 [![travis](https://travis-ci.org/xoseperez/justwifi.svg?branch=master)](https://travis-ci.org/xoseperez/justwifi)
 [![codacy](https://img.shields.io/codacy/grade/4ccbea0317c4415eb2d1c562feced407/master.svg)](https://www.codacy.com/app/xoseperez/justwifi/dashboard)
 [![license](https://img.shields.io/github/license/xoseperez/justwifi.svg)](LICENSE)

--- a/library.json
+++ b/library.json
@@ -1,16 +1,16 @@
 {
     "name": "JustWifi",
     "keywords": "wifi,manager,scan,wps,smartconfig",
-    "description": "Wifi Manager for ESP8266, supports multiple wifi networks, scan for strongest signal, WPS and SmartConfig",
+    "description": "Wifi Manager for ESP8266 and ESP32, supports multiple wifi networks, scan for strongest signal, WPS and SmartConfig",
     "repository": {
         "type": "git",
         "url": "https://github.com/xoseperez/justwifi.git"
     },
-    "version": "2.0.2",
+    "version": "2.0.3",
     "license": "LGPL-3.0",
     "exclude": "tests",
     "frameworks": "arduino",
-    "platforms": "espressif8266",
+    "platforms": ["espressif8266", "espressif32"],
     "authors": {
         "name": "Xose Perez",
         "email": "xose.perez@gmail.com",

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=JustWifi
-version=2.0.2
+version=2.0.3
 author=Xose Pérez <xose.perez@gmail.com>
 maintainer=Xose Pérez <xose.perez@gmail.com>
-sentence=Wifi Manager for ESP8266
+sentence=Wifi Manager for ESP8266 and ESP32
 paragraph=Supports multiple wifi networks, scan for strongest signal, WPS and SmartConfig
 category=Communication
 url=https://github.com/xoseperez/justwifi.git
-architectures=esp8266
+architectures=esp8266,esp32
 includes=JustWifi.h

--- a/src/JustWifi.h
+++ b/src/JustWifi.h
@@ -26,15 +26,20 @@ along with the JustWifi library.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <functional>
 #include <vector>
+#if defined(ARDUINO_ARCH_ESP32)
+#include <WiFi.h>
+#elif defined(ARDUINO_ARCH_ESP8266)
 #include <ESP8266WiFi.h>
+extern "C" {
+    #include "user_interface.h"
+}
+#else
+#error "Non supported architecture!"
+#endif
 
 #ifdef JUSTWIFI_ENABLE_ENTERPRISE
 #include "wpa2_enterprise.h"
 #endif
-
-extern "C" {
-  #include "user_interface.h"
-}
 
 // Check NO_EXTRA_4K_HEAP build flag in SDK 2.4.2
 #include <core_version.h>


### PR DESCRIPTION
For the ESP32 porting of Espurna, it is necessary to have an ESP32 version of JustWifi.
So if you agree with these changes, thanks to merge them.
Most of these modifications are copied from the ESP32 branch.
I also included 2 corrections of STA+AP mode issues.
All tests on my ESP32 are ok.
Sam